### PR TITLE
fix: Cloudfront Path 수정

### DIFF
--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -53,4 +53,4 @@ jobs:
           CLOUD_FRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id $CLOUD_FRONT_ID --paths /*
+            --distribution-id $CLOUD_FRONT_ID --paths "/*"


### PR DESCRIPTION
S3에 올린 후 CloudFront의 캐시를 무효화 해야 소스코드가 바로 적용 됩니다.

무효화 경로가 잘못된것으로 짐작되어 경로를 수정합니다.
현재 이 PR은 테스트입니다.
