### PR TITLE
fix : add trigger pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,58 +1,38 @@
-name: s3-deploy
+name: Deploy
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
-  build-and-test:
-    name: Build and Test
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-    
-      - name: Install Dependencies
-        run: npm install
-
-      - name: Build
-        run: npm run build
-
   deploy:
-    name: Deploy to S3
     runs-on: ubuntu-latest
-    needs: build-and-test
-    if: github.event_name == 'push'
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-    
+
       - name: Install Dependencies
         run: npm install
 
       - name: Build
         run: npm run build
-      
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
-      
+
       - name: Upload to S3
         env:
           BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
         run: |
           aws s3 sync \
             ./public s3://$BUCKET_NAME
-      
+
       - name: CloudFront Invalidation
         env:
           CLOUD_FRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -1,25 +1,36 @@
 name: s3-deploy
 
-# trigger가 되길 바라는 action을 입력합니다. push / pull_request가 있습니다.
-# 저는 develop 브랜치에 push가 되면 actions을 실행하도록 설정했습니다.
 on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
-# 위의 이벤트가 트리거되면 실행할 목록입니다.
 jobs:
-  build:
-    name: React build & deploy
-    # runner가 실행될 환경을 지정합니다.
+  build-and-test:
+    name: Build and Test
     runs-on: ubuntu-latest
     
-    # name은 단계별로 실행되는 액션들의 설명을 담은 것으로, 나중에 github action에서 workflow에 표시됩니다.
-    # uses 키워드로 Action을 불러올 수 있습니다.
     steps:
-      
-      # 레포지토리에 접근하여 CI서버로 코드를 내려받는 과정입니다.
-      - name: checkout Github Action
+      - name: Checkout code
+        uses: actions/checkout@v3
+    
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+  deploy:
+    name: Deploy to S3
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name == 'push'
+    
+    steps:
+      - name: Checkout code
         uses: actions/checkout@v3
     
       - name: Install Dependencies
@@ -28,7 +39,6 @@ jobs:
       - name: Build
         run: npm run build
       
-      # aws에 접근하기 위한 권한을 받아옵니다.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -36,7 +46,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
       
-      # S3에 build 파일을 올립니다.
       - name: Upload to S3
         env:
           BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
@@ -44,10 +53,6 @@ jobs:
           aws s3 sync \
             ./public s3://$BUCKET_NAME
       
-      # cloudfront로 배포되는 파일은 기본설정 상 24시간동안 캐시가 유지됩니다.
-      # 배포 후 S3에는 최신 정적리소스가 올라가있지만 엣지로케이션엔 이전 파일이 올라가있는 상태라는 의미입니다.
-      # 바로 변화가 반영되길 바란다면 invalidation을 해주면 됩니다.
-      # 해당 부분은 과금될 수 있으니 확인 후 사용하세요!
       - name: CloudFront Invalidation
         env:
           CLOUD_FRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}


### PR DESCRIPTION
## 🎫 [지라 티켓 번호] - 없음

## 원인
작업을 하던 도중 종종 pr승인 후 main 브랜치에 병합되었지만
실제 prod 환경에서 build 실패 에러가 종종 검출되곤 합니다.
따라서 main 브랜치로 pull request일때 CI 검사 후 
실패하면 PR 승인을 불허 하였고
그에 따라서 github Action파일을 두 개로 나눴습니다.

trigger를 main 브랜치의 push, pull-request로
pr상태는 build와 추후 lint,test code까지 확인 하는 용도인 ci.yml
pr후 병합상태는 build 후 s3에 deploy하는 형식으로 수정했습니다.

## 🗒️ Note (optional)

main 브랜치로 pull request일때 CI 검사 후 
실패하면 PR 승인을 불허 하였고 
위 과정은

1. GitHub 리포지토리로 이동합니다.
2. Settings 탭을 클릭합니다.
3. Branches 메뉴를 선택합니다.
4. Branch protection rules 섹션에서 Add rule 버튼을 클릭합니다.
5. Branch name pattern에 main을 입력합니다.
6. Require status checks to pass before merging 옵션을 활성화합니다.
7. 생성된 GitHub Actions 워크플로우 저희 jobs이름은 -> build-and-test 
8.Create 버튼을 클릭하여 규칙을 저장합니다.

이렇게 했습니다!