### PR TITLE
제휴문의시 페이지 생성

### DIFF
--- a/src/api/alliance.ts
+++ b/src/api/alliance.ts
@@ -12,27 +12,26 @@ const allianceApi = () => {
     const formatedPlatforms = reservationPlatform.join(',');
 
     try {
-      await requestApi
-        .post(`pre-registration-survey`, {
-          name: contactInfo.name,
-          email: contactInfo.email,
-          phoneNumber: contactInfo.phone,
-          businessName: contactInfo.store,
-          region: region,
-          reservationPlatform: formatedPlatforms,
-          snsContact: contactInfo.snsLink,
-          phoneInterview: shouldInterview,
-        })
-        .then((res) => {
-          if (res.status >= 400) throw Error(res.statusText);
-          alert('등록이 완료되었습니다.');
-        })
-        .catch((e) => {
-          alert('등록이 실패하였습니다. 작성하신 정보를 확인해주세요.');
-          throw Error(e);
-        });
+      const res = await requestApi.post(`pre-registration-survey`, {
+        name: contactInfo.name,
+        email: contactInfo.email,
+        phoneNumber: contactInfo.phone,
+        businessName: contactInfo.store,
+        region: region,
+        reservationPlatform: formatedPlatforms,
+        snsContact: contactInfo.snsLink,
+        phoneInterview: shouldInterview,
+      });
+
+      if (res.status >= 400) {
+        throw new Error(res.statusText);
+      }
+
+      return res; // 성공 시 응답 반환
     } catch (e) {
       console.log(e);
+      alert('등록이 실패하였습니다. 작성하신 정보를 확인해주세요.');
+      throw e;
     }
   };
 

--- a/src/components/Alliance/AllianceContact/AllianceContact.tsx
+++ b/src/components/Alliance/AllianceContact/AllianceContact.tsx
@@ -22,7 +22,7 @@ const AllianceContact = ({ shouldScrollToContact, setIsSuccessSurvey }: Alliance
     store: '',
     snsLink: '',
   });
-
+  
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setContactInfo((prevContactInfo) => ({
@@ -72,12 +72,12 @@ const AllianceContact = ({ shouldScrollToContact, setIsSuccessSurvey }: Alliance
   const allianceContactWrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!allianceContactWrapperRef || !allianceContactWrapperRef.current) return;
-
-    if (shouldScrollToContact) {
+    if (shouldScrollToContact && allianceContactWrapperRef.current) {
       allianceContactWrapperRef.current.scrollIntoView({ behavior: 'smooth' });
+      // 상태 초기화 (선택 사항)
+      window.history.replaceState({}, document.title);
     }
-  }, [allianceContactWrapperRef]);
+  }, [shouldScrollToContact]);
 
   return (
     <section ref={allianceContactWrapperRef} className={styles.AllianceContactWrapper}>

--- a/src/components/Alliance/AllianceContact/AllianceContact.tsx
+++ b/src/components/Alliance/AllianceContact/AllianceContact.tsx
@@ -11,9 +11,10 @@ const { applyContactInfo } = allianceApi();
 
 type AllianceContactProps = {
   shouldScrollToContact: boolean;
+  setIsSuccessSurvey: React.Dispatch<boolean>;
 };
 
-const AllianceContact = ({ shouldScrollToContact }: AllianceContactProps) => {
+const AllianceContact = ({ shouldScrollToContact, setIsSuccessSurvey }: AllianceContactProps) => {
   const [contactInfo, setContactInfo] = useState<ContactInfoType>({
     name: '',
     email: '',
@@ -50,14 +51,22 @@ const AllianceContact = ({ shouldScrollToContact }: AllianceContactProps) => {
     selectedPlatformList.length > 0 &&
     region.length > 0;
 
-  const handleBenefitButton = () => {
+  const handleBenefitButton = async () => {
     if (!validatedBenefitButton) return;
-    applyContactInfo({
-      contactInfo,
-      region: region,
-      reservationPlatform: selectedPlatformList,
-      shouldInterview: selectedInterview,
-    });
+    try {
+      const res = await applyContactInfo({
+        contactInfo,
+        region: region,
+        reservationPlatform: selectedPlatformList,
+        shouldInterview: selectedInterview,
+      });
+      if(res.status >= 201 && res.status < 300) {
+        setIsSuccessSurvey(true);
+      }
+      
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   const allianceContactWrapperRef = useRef<HTMLDivElement>(null);

--- a/src/components/Alliance/SuccessSurvey/SuccessSurvey.module.scss
+++ b/src/components/Alliance/SuccessSurvey/SuccessSurvey.module.scss
@@ -1,0 +1,36 @@
+@import '/src/styles/responsive.scss';
+
+.SuccessSurveyWrapper {
+  background-color: #fefdee;
+  padding: 80px 215px 114px 176px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 30px;
+  @include media(phone, tablet) {
+    padding: 20px;
+  }
+}
+
+.SuccessSurveyTitle {
+  color: var(--Gray-Gray-bk, #000);
+  text-align: center;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 48px; /* 133.333% */
+}
+
+.SuccessSurveyDescription {
+  color: var(--Gray-Gray-bk, #000);
+  text-align: center;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 24px; /* 133.333% */
+}
+
+.SuccessImage {
+  width: 369px;
+  height: 341px;
+}

--- a/src/components/Alliance/SuccessSurvey/SuccessSurvey.tsx
+++ b/src/components/Alliance/SuccessSurvey/SuccessSurvey.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import * as styles from './SuccessSurvey.module.scss';
+import { StaticImage } from 'gatsby-plugin-image';
+const SuccessSurvey = () => {
+  return (
+    <section className={styles.SuccessSurveyWrapper}>
+      <div className={styles.SuccessSurveyTitle}>제출완료</div>
+      <div className={styles.SuccessSurveyDescription}>
+        몽글에 등록해주셔서 감사합니다.
+        <br />
+        기다려주시면 빠르게 회신드리겠습니다.
+      </div>
+      <StaticImage
+        src="../../../images/lending/lending_apply_image.png"
+        alt="LendingApplyImage"
+        className={styles.SuccessImage}
+      />
+    </section>
+  );
+}
+
+export default SuccessSurvey;

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -14,9 +14,7 @@ const Layout = ({ children }: LayoutProps) => {
       <Nav />
       {children}
       <Footer />
-      {typeof window !== 'undefined' && window.location.pathname === '/' && (
-        <ApplyLink className={styles.LayoutMobileApplyLink} />
-      )}
+      <ApplyLink className={styles.LayoutMobileApplyLink} />
     </div>
   );
 };

--- a/src/components/Layout/Nav/Nav.tsx
+++ b/src/components/Layout/Nav/Nav.tsx
@@ -25,9 +25,8 @@ const Nav = () => {
               </li>
             </div>
             <li>
-              {typeof window !== 'undefined' && window.location.pathname === '/' && (
-                <ApplyLink className={styles.BenefitButton} />
-              )}
+              
+              <ApplyLink className={styles.BenefitButton} />
             </li>
           </ul>
         </div>

--- a/src/components/Lending/LendingApply/LedingApply.tsx
+++ b/src/components/Lending/LendingApply/LedingApply.tsx
@@ -15,9 +15,7 @@ const LedingApply = () => {
           <div>반려견의 건강과 미용 서비스를 한 곳에서 모아보고</div>
           <div>효율적으로 관리하세요.</div>
         </div>
-        {typeof window !== 'undefined' && window.location.pathname === '/' && (
-          <ApplyLink className={styles.LendingApplyButton} />
-        )}
+        <ApplyLink className={styles.LendingApplyButton} />
         <div className={styles.LendingApplyPcImageWrapper} data-aos="fade-left">
           <StaticImage
             src="../../../images/lending/lending_apply_image.png"

--- a/src/pages/alliance/index.tsx
+++ b/src/pages/alliance/index.tsx
@@ -5,6 +5,7 @@ import AllianceBenefit from '@components/Alliance/AllianceBenefit/AllianceBenefi
 import AllianceMain from '@components/Alliance/AllianceMain/AllianceMain';
 import AllianceContact from '@components/Alliance/AllianceContact/AllianceContact';
 import Layout from '@components/Layout/Layout';
+import SuccessSurvey from '@src/components/Alliance/SuccessSurvey/SuccessSurvey';
 
 type CustomLocationType = {
   shouldScrollToContact: boolean;
@@ -12,13 +13,24 @@ type CustomLocationType = {
 
 const IndexPage: React.FC<PageProps> = ({ location }) => {
   const state = location.state as CustomLocationType;
-
+  const [isSuccessSurvey, setIsSuccessSurvey] = useState(false);
   return (
     <Layout>
-      <LedingApply />
-      <AllianceMain />
-      <AllianceBenefit />
-      <AllianceContact shouldScrollToContact={state?.shouldScrollToContact} />
+      {isSuccessSurvey ? (
+        <>
+          <SuccessSurvey />
+        </>
+      ) : (
+        <>
+          <LedingApply />
+          <AllianceMain />
+          <AllianceBenefit />
+          <AllianceContact
+            shouldScrollToContact={state?.shouldScrollToContact}
+            setIsSuccessSurvey={setIsSuccessSurvey}
+          />
+        </>
+      )}
     </Layout>
   );
 };

--- a/src/pages/alliance/index.tsx
+++ b/src/pages/alliance/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { HeadFC, PageProps } from 'gatsby';
 import LedingApply from '@components/Lending/LendingApply/LedingApply';
 import AllianceBenefit from '@components/Alliance/AllianceBenefit/AllianceBenefit';
@@ -14,21 +14,45 @@ type CustomLocationType = {
 const IndexPage: React.FC<PageProps> = ({ location }) => {
   const state = location.state as CustomLocationType;
   const [isSuccessSurvey, setIsSuccessSurvey] = useState(false);
+  const allianceContactRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const disableScroll = (e: Event) => e.preventDefault();
+
+    if (state?.shouldScrollToContact && allianceContactRef.current) {
+      document.addEventListener('wheel', disableScroll, { passive: false });
+      document.addEventListener('touchmove', disableScroll, { passive: false });
+
+      allianceContactRef.current.scrollIntoView({ behavior: 'smooth' });
+
+      // 스크롤이 완료된 후 스크롤 이벤트 활성화
+      setTimeout(() => {
+        document.removeEventListener('wheel', disableScroll);
+        document.removeEventListener('touchmove', disableScroll);
+      }, 1000); // 1초 후 스크롤 이벤트 활성화
+    }
+
+    return () => {
+      document.removeEventListener('wheel', disableScroll);
+      document.removeEventListener('touchmove', disableScroll);
+    };
+  }, [state]);
+
   return (
     <Layout>
       {isSuccessSurvey ? (
-        <>
-          <SuccessSurvey />
-        </>
+        <SuccessSurvey />
       ) : (
         <>
           <LedingApply />
           <AllianceMain />
           <AllianceBenefit />
-          <AllianceContact
-            shouldScrollToContact={state?.shouldScrollToContact}
-            setIsSuccessSurvey={setIsSuccessSurvey}
-          />
+          <div ref={allianceContactRef}>
+            <AllianceContact
+              shouldScrollToContact={state?.shouldScrollToContact}
+              setIsSuccessSurvey={setIsSuccessSurvey}
+            />
+          </div>
         </>
       )}
     </Layout>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -46,3 +46,15 @@ li {
 a {
   text-decoration: none;
 }
+
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox  */
+input[type='number'] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
## 🎫 [167]

1. 제휴문의 설문조사 제출완료 화면 구현했습니다. useState로 index페이지에서 성공 실패를 구분합니다.
2. alliance api를 Promise를 then으로 처리하니까 return값이 들어오지 않아서 async await으로 코드를 수정했습니다.
```
const res = await applyContactInfo({
        contactInfo,
        region: region,
        reservationPlatform: selectedPlatformList,
        shouldInterview: selectedInterview,
      });
      if(res.status >= 201 && res.status < 300) {
        setIsSuccessSurvey(true);
      }
```
3.제휴문의 페이지에서 ApplyLink 버튼을 클릭하면 작동하지 않는 문제를 여차저차 해결했는데 useRef가 두 번 이용되서 좀 고민입니다
https://github.com/PBTP/Web-Lending/pull/23/commits/416973ae2b555d8de6dab8f6d6da9ec0c2ce070f
참고 부탁드립니다

<br>

## 🛠️ 작업 내용
![image](https://github.com/PBTP/Web-Lending/assets/49021925/35cabda0-468d-4db9-8913-5c7c18f96c45)

<br>


<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
